### PR TITLE
Add Hash derive and implement Ord and PartialOrd explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "pyver"
 description = "Python PEP-440 Version Parser"
 authors = [
-    "Allstreamer <allstreamer.contact@gmail.com>",
-    "Jan Bronicki <janbronicki@gmail.com>",
+  "Allstreamer <allstreamer.contact@gmail.com>",
+  "Jan Bronicki <janbronicki@gmail.com>",
 ]
 license = "MIT"
 version = "1.0.0"

--- a/deny.toml
+++ b/deny.toml
@@ -18,13 +18,13 @@
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
 targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #{ triple = "x86_64-unknown-linux-musl" },
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+  # The triple can be any string, but only the target triples built in to
+  # rustc (as of 1.40) can be checked against actual config expressions
+  #{ triple = "x86_64-unknown-linux-musl" },
+  # You can also specify which target_features you promise are enabled for a
+  # particular target. target_features are currently not validated against
+  # the actual valid features supported by the target architecture.
+  #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
 ]
 
 # This section is considered when running `cargo deny check advisories`
@@ -48,7 +48,7 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
+  #"RUSTSEC-0000-0000",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -70,16 +70,16 @@ unlicensed = "warn"
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    "MIT",
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "Unicode-DFS-2016",
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "Unicode-DFS-2016",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 deny = [
-    #"Nokia",
+  #"Nokia",
 ]
 # Lint level for licenses considered copyleft
 copyleft = "warn"
@@ -103,9 +103,9 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+  # Each entry is the crate and version constraint, and its specific allow
+  # list
+  #{ allow = ["Zlib"], name = "adler32", version = "*" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
@@ -138,7 +138,7 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-    #"https://sekretz.com/registry
+  #"https://sekretz.com/registry
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -157,28 +157,28 @@ wildcards = "allow"
 highlight = "all"
 # List of crates that are allowed. Use with care!
 allow = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+  #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # List of crates to deny
 deny = [
-    # Each entry the name of a crate and a version range. If version is
-    # not specified, all versions will be matched.
-    #{ name = "ansi_term", version = "=0.11.0" },
-    #
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+  # Each entry the name of a crate and a version range. If version is
+  # not specified, all versions will be matched.
+  #{ name = "ansi_term", version = "=0.11.0" },
+  #
+  # Wrapper crates can optionally be specified to allow the crate when it
+  # is a direct dependency of the otherwise banned crate
+  #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+  #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+  #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/src/ids/dev_id.rs
+++ b/src/ids/dev_id.rs
@@ -17,7 +17,9 @@ use serde::{Deserialize, Serialize};
 ///     DevHead { dev_num: None }
 /// );
 /// ```
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, PartialOrd)]
+#[derive(
+    Hash, Ord, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, PartialOrd,
+)]
 pub struct DevHead {
     pub dev_num: Option<u32>,
 }

--- a/src/ids/post_id.rs
+++ b/src/ids/post_id.rs
@@ -23,7 +23,7 @@ use std::cmp::Ordering;
 ///     }
 /// );
 /// ```
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Hash, Ord, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct PostHeader {
     pub post_head: Option<PostHead>,
     pub post_num: Option<u32>,
@@ -36,7 +36,7 @@ pub struct PostHeader {
 /// Examples of versions that use this enum:
 /// - `1.0.post456`
 /// - `1.0rev`
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Ord, Hash, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum PostHead {
     /// ```
     /// use pyver::ids::PostHead;

--- a/src/ids/post_id.rs
+++ b/src/ids/post_id.rs
@@ -23,7 +23,7 @@ use std::cmp::Ordering;
 ///     }
 /// );
 /// ```
-#[derive(Hash, Ord, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Hash, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct PostHeader {
     pub post_head: Option<PostHead>,
     pub post_num: Option<u32>,
@@ -36,7 +36,7 @@ pub struct PostHeader {
 /// Examples of versions that use this enum:
 /// - `1.0.post456`
 /// - `1.0rev`
-#[derive(Ord, Hash, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Hash, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum PostHead {
     /// ```
     /// use pyver::ids::PostHead;
@@ -52,28 +52,40 @@ pub enum PostHead {
     Rev,
 }
 
+impl Ord for PostHead {
+    fn cmp(&self, _other: &Self) -> Ordering {
+        Ordering::Equal
+    }
+}
+
 impl PartialOrd for PostHead {
     fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
         Some(Ordering::Equal)
     }
 }
 
-impl PartialOrd for PostHeader {
+impl PartialOrd<Self> for PostHeader {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PostHeader {
+    fn cmp(&self, other: &Self) -> Ordering {
         if self.post_num == other.post_num {
-            return Some(Ordering::Equal);
+            return Ordering::Equal;
         }
 
         if self.post_num.is_none() && other.post_num.is_some() {
-            return Some(Ordering::Less);
+            return Ordering::Less;
         } else if self.post_num.is_some() && other.post_num.is_none() {
-            return Some(Ordering::Greater);
+            return Ordering::Greater;
         }
 
         if self.post_num < other.post_num {
-            Some(Ordering::Less)
+            Ordering::Less
         } else {
-            Some(Ordering::Greater)
+            Ordering::Greater
         }
     }
 }

--- a/src/ids/pre_id.rs
+++ b/src/ids/pre_id.rs
@@ -2,7 +2,9 @@ use serde::{Deserialize, Serialize};
 
 /// # `PEP-440` Pre-Release identifier
 /// This identifier is used to mark a Pre-Release version
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, PartialOrd)]
+#[derive(
+    Hash, Ord, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, PartialOrd,
+)]
 pub enum PreHeader {
     /// Present in versions like 1.1beta1 or 1.0b1 both are represented the same way
     /// ```

--- a/src/ids/release_id.rs
+++ b/src/ids/release_id.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 /// `PEP-440` Release numbers
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, PartialOrd)]
+#[derive(
+    Hash, Ord, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, PartialOrd,
+)]
 pub struct ReleaseHeader {
     /// Major release such as 1.0 or breaking changes
     pub major: u32,

--- a/src/version.rs
+++ b/src/version.rs
@@ -16,8 +16,8 @@ use std::hash::{Hash, Hasher};
 ///# use pyver::PackageVersion;
 /// let _ = PackageVersion::new("v1.0");
 /// ```
-#[derive(Ord, Clone, Derivative, Debug, Serialize, Deserialize)]
-#[derivative(PartialOrd)]
+#[derive(Clone, Derivative, Debug, Serialize, Deserialize)]
+#[derivative(PartialOrd, Ord)]
 pub struct PackageVersion {
     /// ## Original String
     /// Just holds the original string passed in when creating
@@ -328,11 +328,14 @@ mod tests {
             "1.1.dev1",
         ];
 
-        let mut some_hash = HashMap::new();
+        let mut some_hash: HashMap<PackageVersion, String> = HashMap::new();
 
-        for i in 0..versions.len() {
-            some_hash.insert(versions[i], i);
+        for i in versions {
+            some_hash.insert(PackageVersion::new(i).unwrap(), i.to_string());
         }
+
+        some_hash.get(&PackageVersion::new("1.0").unwrap());
+
         Ok(())
     }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -3,6 +3,7 @@ use super::validate_440_version;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 
 /// `PEP-440` Compliant versioning system
 ///
@@ -15,8 +16,8 @@ use std::fmt;
 ///# use pyver::PackageVersion;
 /// let _ = PackageVersion::new("v1.0");
 /// ```
-#[derive(Derivative, Debug, Serialize, Deserialize)]
-#[derivative(PartialOrd, PartialEq)]
+#[derive(Ord, Clone, Derivative, Debug, Serialize, Deserialize)]
+#[derivative(PartialOrd)]
 pub struct PackageVersion {
     /// ## Original String
     /// Just holds the original string passed in when creating
@@ -173,10 +174,44 @@ impl fmt::Display for PackageVersion {
     }
 }
 
+impl PartialEq<Self> for PackageVersion {
+    fn eq(&self, other: &Self) -> bool {
+        self.release == other.release
+            && self.local == other.local
+            && self.dev == other.dev
+            && self.epoch == other.epoch
+            && self.post == other.post
+            && self.pre == other.pre
+    }
+}
+
+impl Eq for PackageVersion {}
+
+/// The hash of the `PackageVersion` is calculated only from the `original` field.
+impl Hash for PackageVersion {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.release.hash(state);
+        self.local.hash(state);
+        self.dev.hash(state);
+        self.epoch.hash(state);
+        self.post.hash(state);
+        self.pre.hash(state);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::PackageVersion;
     use anyhow::Result;
+    use std::collections::hash_map::DefaultHasher;
+    use std::collections::HashMap;
+    use std::hash::{Hash, Hasher};
+
+    fn default_hash<T: Hash>(value: &T) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
 
     #[test]
     fn test_pep440_ordering() -> Result<()> {
@@ -184,8 +219,8 @@ mod tests {
             PackageVersion::new(
                 "v1!1.0-preview-921.post-516.dev-241+yeah.this.is.the.problem.with.local.versions",
             )?
-            >
-            PackageVersion::new("1.0")?
+                >
+                PackageVersion::new("1.0")?
         );
         Ok(())
     }
@@ -258,5 +293,72 @@ mod tests {
                 Err(_e) => continue,
             }
         }
+    }
+
+    #[test]
+    fn test_use_package_version_as_hash_key() -> Result<()> {
+        let versions = vec![
+            "1.0",
+            "v1.1",
+            "2.0",
+            "2013.10",
+            "2014.04",
+            "1!1.0",
+            "1!1.1",
+            "1!2.0",
+            "2!1.0.pre0",
+            "1.0.dev456",
+            "1.0a1",
+            "1.0a2.dev456",
+            "1.0a12.dev456",
+            "1.0a12",
+            "1.0b1.dev456",
+            "1.0b2",
+            "1.0b2.post345.dev456",
+            "1.0b2.post345",
+            "1.0rc1.dev456",
+            "1.0rc1",
+            "1.0",
+            "1.0+abc.5",
+            "1.0+abc.7",
+            "1.0+5",
+            "1.0.post456.dev34",
+            "1.0.post456",
+            "1.0.15",
+            "1.1.dev1",
+        ];
+
+        let mut some_hash = HashMap::new();
+
+        for i in 0..versions.len() {
+            some_hash.insert(versions[i], i);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_hashing_and_eq() -> Result<()> {
+        assert_eq!(
+            default_hash(&PackageVersion::new("1.0a1")?),
+            default_hash(&PackageVersion::new("1.0alpha1")?)
+        );
+        assert_eq!(
+            default_hash(&PackageVersion::new("1.0b")?),
+            default_hash(&PackageVersion::new("1.0beta")?)
+        );
+        assert_eq!(
+            default_hash(&PackageVersion::new("1.0r")?),
+            default_hash(&PackageVersion::new("1.0rev")?)
+        );
+        assert_eq!(
+            default_hash(&PackageVersion::new("1.0c")?),
+            default_hash(&PackageVersion::new("1.0rc")?)
+        );
+        assert_eq!(
+            default_hash(&PackageVersion::new("v1.0")?),
+            default_hash(&PackageVersion::new("1.0")?)
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Add Hash derive and implement Ord and PartialOrd explicitly so that the `pyver`s structs can be used inside a Hash map