### PR TITLE
Add a CHANGELOG checking CI job

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,20 @@
+name: 📜 Check CHANGELOG update on PR
+
+on:
+  pull_request:
+    branches:
+      - "develop"
+
+jobs:
+  formatting-check:
+    name: 📜 Check CHANGELOG update on PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check changelog diff compared to target branch
+        # If the changelog is not edit the job should fail
+        run: |
+          git fetch origin $GITHUB_BASE_REF
+          HEAD_SHA=$(git rev-parse HEAD)
+          BASE_SHA=$(git rev-parse origin/$GITHUB_BASE_REF)
+          git diff --exit-code $HEAD_SHA $BASE_SHA -- CHANGELOG.md || exit 0 && exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to:
 * Added Github Actions for (cargo check, cargo fmt, cargo clippy, cargo test) [#10](https://github.com/Allstreamer/pyver/pull/10)
 * Added CHANGELOG.md
 * Added `ids` module
+* Added the capability to use the `PackageVersion` struct as a HashMap key [#28](https://github.com/Rust-Python-Packaging/pyver/pull/28)
 
 ### Changed
 


### PR DESCRIPTION
Add a Ci check that checks if the CHANGELOG was updated in a PR.

Based on the command:
```bash
                  git fetch origin $GITHUB_BASE_REF
                  HEAD_SHA=$(git rev-parse HEAD)
                  BASE_SHA=$(git rev-parse origin/$GITHUB_BASE_REF)
                  git diff --exit-code $HEAD_SHA $BASE_SHA -- CHANGELOG.md || exit 0 && exit 1
```